### PR TITLE
Remove unnecessary tags for vast.ai

### DIFF
--- a/docker/config.yml
+++ b/docker/config.yml
@@ -21,12 +21,3 @@ default_stockfish:
   base: default
   stockfish: True
   tag_suffix: -stockfish
-
-vastai:
-  base: default
-  tag_suffix: -vastai
-
-vastai_stockfish:
-  base: vastai
-  tag_suffix: -stockfish-vastai
-  stockfish: True


### PR DESCRIPTION
They were obsolete anyway and a copy of the default profiles.