### PR TITLE
Automatically use multiple GPUs

### DIFF
--- a/docker/scripts/run_lc0
+++ b/docker/scripts/run_lc0
@@ -1,7 +1,45 @@
 #!/usr/bin/env bash
 
+FLAGS="$LC0_FLAGS $@"
+
 export weights_path=/lc0/weights
 NETWORK=$(/lc0/network_parse $NETWORK)
 
-/lc0/lc0 $@ $LC0_FLAGS --weights=${weights_path}/${NETWORK}
+# check if Nvidia GPU
+if nvidia-smi >/dev/null 2>&1; then
+    # count GPUs
+    gpu_count=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+    # don't apply this if: less than 2 GPUs or backend other
+    # than cuda-* or cudnn-* is set
+    # or any backend-opts are set
+    if [ $gpu_count -gt 1 ] && \
+       [[ ! "$FLAGS" =~ --backend-opts ]] && \
+       ( [[ "$FLAGS" =~ --backend=(cud|demux|multiplexing|roundrobin) ]] || \
+         [[ ! "$FLAGS" =~ --backend ]] )
+    then
+        # check for backend involving cuda -> will be used on all GPUs
+        if [[ "$FLAGS" =~ (.*)--backend=(cud[a-z0-9-]+)(.*) ]]; then
+            backend=${BASH_REMATCH[2]}
+            FLAGS=${BASH_REMATCH[1]}${BASH_REMATCH[3]}
+        else
+            backend="cudnn-auto"
+        fi
 
+        # check for multiplexing backend
+        if [[ "$FLAGS" =~ (.*)--backend=(demux|multiplexing|roundrobin)(.*) ]]; then
+            multi_gpu_backend=${BASH_REMATCH[2]}
+            FLAGS=${BASH_REMATCH[1]}${BASH_REMATCH[3]}
+        else
+            multi_gpu_backend="demux"
+        fi
+        echo "GPU count: $gpu_count"
+        MULTIGPU_FLAGS="--backend=${multi_gpu_backend} \
+            --backend-opts=backend=${backend},$(for i in $(seq 0 $(expr $gpu_count - 1)); \
+                                                do echo -n "(gpu=$i),"; done)"
+        MULTIGPU_FLAGS=$(echo -n $MULTIGPU_FLAGS | xargs)
+    fi
+fi
+
+FLAGS="$FLAGS --weights=${weights_path}/${NETWORK} $MULTIGPU_FLAGS"
+echo "Running lc0 with flags: $FLAGS"
+/lc0/lc0 $FLAGS


### PR DESCRIPTION
lc0 doesn't use multiple GPUs automatically, it needs a multi-GPU specific backend with each GPU specified set.
This PR implements this by using `nvidia-smi` to count GPUs, and then sets the required flags.
(only works with Nvidia)

This can be additionally control with the backend flag:
- if `--backend=` is set to one of the Nvidia-based backends (`cudnn-auto`, `cuda-auto`, etc), this backend will then be used on the individual GPUs  (e.g. if `--backend=cuda-fp16` is given with 2 GPUs detected, this will be transformed to `--backend=demux --backend-opts=backend=cuda-fp16,(gpu=0),(gpu=1)`
- if `--backend=` is set to one of the multi-GPU backends (`demux`, `roundrobin`, `multiplexing`), then this backend will be used to manage the GPUs (e.g. `--backend=roundrobin` will be transformed to `--backend=roundrobin --backend-opts=backend=cudnn-auto,(gpu=0),(gpu=1)`)
- for any non-Nvidia backend not flags are changed
- if any `--backend-opts` are given no flags will be changed, and multiple GPUs have to be configured manually.
- There is currently no way to both specify the multi-GPU backend, and the backend on the GPUs themselves. If this is needed the GPUs have to be managed manually.

This PR is available to test under the docker tag suffix `-multigpu`:
- `docker.io/simske/lc0:0.28-rc-multigpu`
- `docker.io/simske/0.28-rc-stockfish-multigpu`

TODO
- [X] Implement behaviour described above
- [ ] Update Readme